### PR TITLE
Fix for parallel tests

### DIFF
--- a/src/NUnitFramework/framework/Internal/Commands/FixturePerTestCaseCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/FixturePerTestCaseCommand.cs
@@ -53,17 +53,15 @@ namespace NUnit.Framework.Internal.Commands
 
             BeforeTest = (context) =>
             {
-                if (typeInfo != null && !typeInfo.IsStaticClass && testSuite.Fixture == null)
+                if (typeInfo != null && !typeInfo.IsStaticClass)
                 {
                     context.TestObject = typeInfo.Construct(testSuite.Arguments);
                     Test.Fixture = context.TestObject;
-                    testSuite.Fixture = context.TestObject;
                 }
             };
 
             AfterTest = (context) =>
             {
-                testSuite.Fixture = null;
             };
         }
     }

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2019 Charlie Poole, Rob Prouse
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -23,9 +23,6 @@
 
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 
 namespace NUnit.TestData.LifeCycleTests
@@ -52,26 +49,41 @@ namespace NUnit.TestData.LifeCycleTests
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class SetupAndTearDownFixtureInstancePerTestCase
     {
-        public int TotalSetupCount = 0;
-        public int TotalTearDownCount = 0;
+        int _totalSetupCount = 0;
+        int _totalTearDownCount = 0;
 
         [SetUp]
         public void Setup()
         {
-            TotalSetupCount++;
+            _totalSetupCount++;
         }
 
         [TearDown]
         public void TearDown()
         {
-            TotalTearDownCount++;
+            _totalTearDownCount++;
         }
 
         [Test]
-        public void DummyTest1() { }
+        public void DummyTest1() 
+        {
+            Assert.That(_totalSetupCount, Is.EqualTo(1)); 
+            Assert.That(_totalTearDownCount, Is.EqualTo(0));
+        }
 
         [Test]
-        public void DummyTest2() { }
+        public void DummyTest2()
+        {
+            Assert.That(_totalSetupCount, Is.EqualTo(1));
+            Assert.That(_totalTearDownCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void DummyTest3()
+        {
+            Assert.That(_totalSetupCount, Is.EqualTo(1));
+            Assert.That(_totalTearDownCount, Is.EqualTo(0));
+        }
     }
 
     [TestFixture]
@@ -191,5 +203,25 @@ namespace NUnit.TestData.LifeCycleTests
             RepeatCounter++;
             Assert.That(Counter, Is.EqualTo(1));
         }
+    }
+
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    [Parallelizable(ParallelScope.All)]
+    public class ParallelLifeCycleFixtureInstancePerTestCase
+    {
+        public static int ConstructorCount = 0;
+
+        public ParallelLifeCycleFixtureInstancePerTestCase()
+        {
+            ConstructorCount++;
+        }
+
+        [Test]
+        public void DummyTest1() { }
+        [Test]
+        public void DummyTest2() { }
+        [Test]
+        public void DummyTest3() { }
     }
 }

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -210,18 +210,30 @@ namespace NUnit.TestData.LifeCycleTests
     [Parallelizable(ParallelScope.All)]
     public class ParallelLifeCycleFixtureInstancePerTestCase
     {
-        public static int ConstructorCount = 0;
+        int _setupCount = 0;
 
-        public ParallelLifeCycleFixtureInstancePerTestCase()
+        [SetUp]
+        public void SetUp()
         {
-            ConstructorCount++;
+            _setupCount++;
         }
 
         [Test]
-        public void DummyTest1() { }
+        public void DummyTest1() 
+        {
+            Assert.That(_setupCount, Is.EqualTo(1));
+        }
+
         [Test]
-        public void DummyTest2() { }
+        public void DummyTest2()
+        {
+            Assert.That(_setupCount, Is.EqualTo(1));
+        }
+
         [Test]
-        public void DummyTest3() { }
+        public void DummyTest3()
+        {
+            Assert.That(_setupCount, Is.EqualTo(1));
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeParallelTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeParallelTests.cs
@@ -1,0 +1,79 @@
+// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Runtime.Serialization;
+
+namespace NUnit.Framework.Attributes
+{
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    [Parallelizable(ParallelScope.All)]
+    public class LifeCycleAttributeParallelTests
+    {
+        static ObjectIDGenerator generator = new ObjectIDGenerator();
+        int constructorCount = 0;
+        int setupCount = 0;
+
+        public LifeCycleAttributeParallelTests()
+        {
+            OutputReferenceId("Ctor");
+            constructorCount++;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            OutputReferenceId("SetUp");
+            setupCount++;
+        }
+
+        [Test]
+        public void EnsureParallelTestsRunInNewInstance1()
+        {
+            OutputReferenceId("EnsureParallelTestsRunInNewInstance1");
+            Assert.That(constructorCount, Is.EqualTo(1)); 
+            Assert.That(setupCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void EnsureParallelTestsRunInNewInstance2()
+        {
+            OutputReferenceId("EnsureParallelTestsRunInNewInstance2");
+            Assert.That(constructorCount, Is.EqualTo(1));
+            Assert.That(setupCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void EnsureParallelTestsRunInNewInstance3()
+        {
+            OutputReferenceId("EnsureParallelTestsRunInNewInstance3");
+            Assert.That(constructorCount, Is.EqualTo(1));
+            Assert.That(setupCount, Is.EqualTo(1));
+        }
+
+        private void OutputReferenceId(string location)
+        {
+            long id = generator.GetId(this, out bool _);
+            TestContext.WriteLine($"{location}: {id}>");
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -117,7 +117,6 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void ConstructorIsCalledOnceForEachTestInParallelTests()
         {
-            ParallelLifeCycleFixtureInstancePerTestCase.ConstructorCount = 0;
             var fixture = TestBuilder.MakeFixture(typeof(ParallelLifeCycleFixtureInstancePerTestCase)); 
             
             ITestResult result = TestBuilder.RunTest(fixture);

--- a/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/LifeCycleAttributeTests.cs
@@ -35,11 +35,11 @@ namespace NUnit.Framework.Attributes
         [Test]
         public void SetupTearDownIsCalledOnce()
         {
-            var fixture = new SetupAndTearDownFixtureInstancePerTestCase();
-            TestBuilder.RunTestFixture(fixture);
+            var fixture = TestBuilder.MakeFixture(typeof(SetupAndTearDownFixtureInstancePerTestCase));
 
-            Assert.AreEqual(1, fixture.TotalSetupCount);
-            Assert.AreEqual(1, fixture.TotalTearDownCount);
+            ITestResult result = TestBuilder.RunTest(fixture);
+
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed), result.Message);
         }
 
         [Test]
@@ -112,6 +112,16 @@ namespace NUnit.Framework.Attributes
             Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
 
             Assert.AreEqual(3, RepeatingLifeCycleFixtureInstancePerTestCase.RepeatCounter);
+        }
+
+        [Test]
+        public void ConstructorIsCalledOnceForEachTestInParallelTests()
+        {
+            ParallelLifeCycleFixtureInstancePerTestCase.ConstructorCount = 0;
+            var fixture = TestBuilder.MakeFixture(typeof(ParallelLifeCycleFixtureInstancePerTestCase)); 
+            
+            ITestResult result = TestBuilder.RunTest(fixture);
+            Assert.That(result.ResultState.Status, Is.EqualTo(TestStatus.Passed));
         }
     }
 }


### PR DESCRIPTION
I will explain the changes inline. My main concern is why you included the code in `FixtureperTestCaseCommand` that I deleted? After I deleted it and fixed one of your tests, everything seems to work fine including my integration tests.